### PR TITLE
Clear purchase-attributed clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,8 +474,10 @@ See PA Docs: [Best Practices](https://docs.particularaudience.com/recommendation
 1. **Click Event Storage**: When you track a click event, the SDK automatically stores attribution data for that product
 2. **Automatic Retrieval**: Add to cart, checkout, and purchase events automatically include stored attribution data
 3. **Separate Tracking**: Sponsored and organic clicks are tracked separately for proper attribution
-4. **Attribution Window**: Data is stored for 30 days by default (configurable)
-5. **Cross-Session Persistence**: Attribution data persists across browser sessions using cookies or localStorage
+4. **Priority Handling**: Sponsored attribution is used first; organic attribution is only used if no sponsored data exists
+5. **Attribution Window**: Data is stored for 30 days by default (configurable)
+6. **Cross-Session Persistence**: Attribution data persists across browser sessions using cookies or localStorage
+7. **Automatic Cleanup**: Stored attribution is cleared once the window expires or after it has been used for a purchase
 
 ### Configuration:
 
@@ -514,6 +516,10 @@ await paSDK.trackPurchase({
   // Attribution data is automatically merged for each product
 });
 ```
+
+Once a purchase is tracked, the SDK discards the stored sponsored or organic
+attribution used for the products involved, ensuring new clicks are required
+for future purchases.
 
 ### Manual Attribution (if needed):
 

--- a/pa-sdk.js
+++ b/pa-sdk.js
@@ -1048,17 +1048,21 @@
     }
 
     /**
-     * Get stored attribution data for a product
-     * prioritising sponsored clicks
-     * @private
-     */
+    * Get stored attribution data for a product
+    * prioritising sponsored clicks
+    * @private
+    */
     _getAttributionData(productRefId) {
       if (!this.session.customerId || !productRefId) {
         return null;
       }
+      // Always prefer sponsored attribution when both types are available
+      const sponsored = this._getAttributionDataFor(productRefId, true);
+      if (sponsored) {
+        return sponsored;
+      }
 
-      return this._getAttributionDataFor(productRefId, true) ||
-             this._getAttributionDataFor(productRefId, false);
+      return this._getAttributionDataFor(productRefId, false);
     }
 
     /**

--- a/pa-sdk.js
+++ b/pa-sdk.js
@@ -332,20 +332,38 @@
      * @see https://docs.particularaudience.com/events/event-purchases - Purchase Event API
      */
     async trackPurchase(eventData) {
+      const products = [];
+      const consumedAttribution = [];
+
+      eventData.products.forEach(product => {
+        const { product: enrichedProduct, attributionData } = this._prepareProductWithAttribution(product);
+        products.push(enrichedProduct);
+        if (attributionData) {
+          consumedAttribution.push({ refId: product.refId, isSponsored: attributionData.isSponsored });
+        }
+      });
+
       const event = {
         currentUrl: eventData.currentUrl || window.location.href,
         eventTime: new Date().toISOString(),
         orderId: eventData.orderId,
         paymentMethod: eventData.paymentMethod,
         currencyCode: eventData.currencyCode,
-        products: eventData.products.map(product => this._enrichProductDataWithAttribution(product)),
+        products,
         priceBeatPromotions: eventData.priceBeatPromotions,
         recommenderId: eventData.recommenderId,
         campaignId: eventData.campaignId,
         tacticId: eventData.tacticId
       };
 
-      return this._queueEvent('purchases', event);
+      const queuedEvent = this._queueEvent('purchases', event);
+
+      // Remove consumed attribution data so future purchases require new clicks
+      consumedAttribution.forEach(item => {
+        this._cleanupExpiredAttributionData(item.refId, item.isSponsored);
+      });
+
+      return queuedEvent;
     }
 
     /**
@@ -771,18 +789,28 @@
     }
 
     /**
+     * Prepare product data and return any attribution used
+     * @private
+     */
+    _prepareProductWithAttribution(product) {
+      const attributionData = this._getAttributionData(product.refId);
+      const baseProduct = this._enrichProductData(product);
+      const productWithAttr = attributionData ?
+        this._mergeAttributionData(baseProduct, attributionData) :
+        baseProduct;
+
+      return {
+        product: productWithAttr,
+        attributionData
+      };
+    }
+
+    /**
      * Enrich product data with attribution tracking fields
      * @private
      */
     _enrichProductDataWithAttribution(product) {
-      const attributionData = this._getAttributionData(product.refId);
-      const baseProduct = this._enrichProductData(product);
-      
-      if (attributionData) {
-        return this._mergeAttributionData(baseProduct, attributionData);
-      }
-      
-      return baseProduct;
+      return this._prepareProductWithAttribution(product).product;
     }
 
     /**
@@ -920,7 +948,9 @@
         return;
       }
 
-      const storageKey = `${this.config.cookiePrefix}attribution_${this.session.customerId}_${productRefId}`;
+      const typeSuffix = clickData.isSponsored ? 's' : 'o';
+      const storageKey = `${this.config.cookiePrefix}attribution_${this.session.customerId}_${productRefId}_${typeSuffix}`;
+      const mapKey = `${productRefId}_${typeSuffix}`;
       const attributionData = {
         clickId: clickData.clickId,
         eventTime: clickData.eventTime,
@@ -956,7 +986,7 @@
 
       try {
         // Store in memory cache for current session
-        this.attributionData.set(productRefId, attributionData);
+        this.attributionData.set(mapKey, attributionData);
 
         // Store persistently
         if (this.config.storageType === 'localStorage' && typeof localStorage !== 'undefined') {
@@ -973,27 +1003,25 @@
     }
 
     /**
-     * Get stored attribution data for a product
+     * Get stored attribution data of a specific type
      * @private
      */
-    _getAttributionData(productRefId) {
-      if (!this.session.customerId || !productRefId) {
-        return null;
-      }
+    _getAttributionDataFor(productRefId, isSponsored) {
+      const typeSuffix = isSponsored ? 's' : 'o';
+      const mapKey = `${productRefId}_${typeSuffix}`;
+      const storageKey = `${this.config.cookiePrefix}attribution_${this.session.customerId}_${productRefId}_${typeSuffix}`;
 
       // First check memory cache
-      if (this.attributionData.has(productRefId)) {
-        const data = this.attributionData.get(productRefId);
+      if (this.attributionData.has(mapKey)) {
+        const data = this.attributionData.get(mapKey);
         if (data.expiresAt > Date.now()) {
           return data;
         } else {
-          this.attributionData.delete(productRefId);
+          this.attributionData.delete(mapKey);
         }
       }
 
       // Then check persistent storage
-      const storageKey = `${this.config.cookiePrefix}attribution_${this.session.customerId}_${productRefId}`;
-      
       try {
         let storedData;
         if (this.config.storageType === 'localStorage' && typeof localStorage !== 'undefined') {
@@ -1004,15 +1032,12 @@
 
         if (storedData) {
           const attributionData = JSON.parse(storedData);
-          
-          // Check if data has expired
+
           if (attributionData.expiresAt > Date.now()) {
-            // Add to memory cache for faster access
-            this.attributionData.set(productRefId, attributionData);
+            this.attributionData.set(mapKey, attributionData);
             return attributionData;
           } else {
-            // Clean up expired data
-            this._cleanupExpiredAttributionData(productRefId);
+            this._cleanupExpiredAttributionData(productRefId, isSponsored);
           }
         }
       } catch (error) {
@@ -1020,6 +1045,20 @@
       }
 
       return null;
+    }
+
+    /**
+     * Get stored attribution data for a product
+     * prioritising sponsored clicks
+     * @private
+     */
+    _getAttributionData(productRefId) {
+      if (!this.session.customerId || !productRefId) {
+        return null;
+      }
+
+      return this._getAttributionDataFor(productRefId, true) ||
+             this._getAttributionDataFor(productRefId, false);
     }
 
     /**
@@ -1058,28 +1097,33 @@
     }
 
     /**
-     * Clean up expired attribution data
+     * Clean up attribution data
      * @private
      */
-    _cleanupExpiredAttributionData(productRefId) {
+    _cleanupExpiredAttributionData(productRefId, isSponsored = null) {
       if (!this.session.customerId) return;
-      
-      const storageKey = `${this.config.cookiePrefix}attribution_${this.session.customerId}_${productRefId}`;
-      
-      // Remove from memory
-      this.attributionData.delete(productRefId);
-      
-      // Remove from persistent storage
-      try {
-        if (this.config.storageType === 'localStorage' && typeof localStorage !== 'undefined') {
-          localStorage.removeItem(storageKey);
-        } else {
-          // Set cookie with past expiration date to delete it
-          this._setCookie(storageKey, '', 'Thu, 01 Jan 1970 00:00:00 UTC');
+
+      const types = isSponsored === null ? [true, false] : [isSponsored];
+
+      types.forEach(type => {
+        const suffix = type ? 's' : 'o';
+        const mapKey = `${productRefId}_${suffix}`;
+        const storageKey = `${this.config.cookiePrefix}attribution_${this.session.customerId}_${productRefId}_${suffix}`;
+
+        // Remove from memory
+        this.attributionData.delete(mapKey);
+
+        // Remove from persistent storage
+        try {
+          if (this.config.storageType === 'localStorage' && typeof localStorage !== 'undefined') {
+            localStorage.removeItem(storageKey);
+          } else {
+            this._setCookie(storageKey, '', 'Thu, 01 Jan 1970 00:00:00 UTC');
+          }
+        } catch (error) {
+          this._error('Failed to cleanup expired attribution data:', error);
         }
-      } catch (error) {
-        this._error('Failed to cleanup expired attribution data:', error);
-      }
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- store sponsored and organic click attribution separately per product
- prioritise sponsored attribution for events and remove whichever type was used after purchase
- document attribution priority and cleanup behaviour

## Testing
- `node --check pa-sdk.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_689995c419d4832eaf3c422db29df4a5